### PR TITLE
Fix prop type error

### DIFF
--- a/client/src/editBlogPage/PastBlogPosts.jsx
+++ b/client/src/editBlogPage/PastBlogPosts.jsx
@@ -37,7 +37,7 @@ export default function PastBlogPosts({ onPostClick = () => {}, posts }) {
 }
 PastBlogPosts.propTypes = {
   onPostClick: PropTypes.func.isRequired,
-  posts: PropTypes.arrayOf.isRequired,
+  posts: PropTypes.instanceOf(Array).isRequired,
 };
 
 const PastBlogPostContainer = styled(ListTile)`

--- a/client/src/editBlogPage/PastBlogPosts.jsx
+++ b/client/src/editBlogPage/PastBlogPosts.jsx
@@ -37,7 +37,10 @@ export default function PastBlogPosts({ onPostClick = () => {}, posts }) {
 }
 PastBlogPosts.propTypes = {
   onPostClick: PropTypes.func.isRequired,
-  posts: PropTypes.instanceOf(Array).isRequired,
+  posts: PropTypes.instanceOf(Array),
+};
+PastBlogPosts.defaultProps = {
+  posts: [],
 };
 
 const PastBlogPostContainer = styled(ListTile)`


### PR DESCRIPTION
Bug: Warning: Failed prop type: PastBlogPosts: prop type `posts` is invalid; it must be a function, usually from the `prop-types` package, but received `undefined`

