### PR TITLE
Git: Ignoring the build bundles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -85,7 +85,7 @@ typings/
 
 # Nuxt.js build / generate output
 .nuxt
-client/dist/main.js
+client/dist/*main.js
 
 # Gatsby files
 .cache/


### PR DESCRIPTION
Changes how git handles bundle files, keeps them out of the repo